### PR TITLE
Refer to DATABASES as a setting, not a variable

### DIFF
--- a/source/connect.txt
+++ b/source/connect.txt
@@ -23,14 +23,14 @@ Overview
 In this guide, you can learn how to configure your Django project's
 connection to MongoDB.
 
-Connection Configuration 
+Connection Configuration
 ------------------------
 
 After installing {+django-odm+} and creating a project, you can configure
 your connection to MongoDB in the following ways:
 
 - :ref:`django-connection-configure-manual` by specifying the
-  ``DATABASES`` variable in your project's settings.
+  ``DATABASES`` setting in your project's settings.
 - :ref:`django-connection-configure-automatic` by using
   the ``parse_uri()`` function.
 
@@ -44,10 +44,9 @@ your connection to MongoDB in the following ways:
 Manually Configure Database Settings
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-To manually configure your connection to MongoDB, update
-the ``DATABASES`` variable in your project's ``settings.py``
-file. Set the ``DATABASES`` variable to a dictionary value containing
-the ``default`` key, as shown in the following example: 
+To manually configure your connection to MongoDB, update the
+``DATABASES`` setting in your project's ``settings.py`` file. Set it to
+a dictionary containing the ``default`` key:
 
 .. code-block:: python
 
@@ -71,7 +70,7 @@ This nested dictionary has the following keys:
      - The backend driver to use for the connection. Set this key to ``"django_mongodb_backend"``.
 
    * - **HOST**
-     - | Your connection URI. For localhost connections, this key is optional. 
+     - | Your connection URI. For localhost connections, this key is optional.
        | For SRV connections, you must include a scheme prefix (``mongodb+srv://``).
        |
        | To specify more than one host, include all hostnames in one string. Use
@@ -101,11 +100,10 @@ This nested dictionary has the following keys:
 
 .. _django-manual-config-example:
 
-Example 
+Example
 ```````
 
-In this example, the ``DATABASES`` variable performs the
-following actions:
+In this example, the ``DATABASES`` setting performs the following actions:
 
 - Sets the database to ``my_database``
 - Provides authentication information for a database user
@@ -146,15 +144,15 @@ function accepts the following arguments:
 
 - ``uri``: Your MongoDB connection URI.
 - ``conn_max_age``: Configures persistent database connections.
-  This argument is optional. To learn more, see 
+  This argument is optional. To learn more, see
   `Persistent connections <{+django-docs+}/ref/databases/#persistent-database-connections>`__
   in the {+framework+} documentation.
 - ``test``: Provides a dictionary of settings for test
-  databases. This argument is optional. To learn more, see 
+  databases. This argument is optional. To learn more, see
   `the TEST setting <{+django-docs+}/ref/settings/#test>`__
   in the {+framework+} documentation.
 
-Example 
+Example
 ```````
 
 The following example uses the ``parse_uri()`` function to specify


### PR DESCRIPTION
@norareidy tip: You might be able to configure your text editor to remove trailing spaces on save, add a newline to the EOF if not present, as well as display a right margin at 72 characters for easier text wrapping. Mine is set accordingly and that's why those changes are appearing on my PRs. :-)