### PR TITLE
Correction: QuerySet.distinct() is supported

### DIFF
--- a/source/limitations-upcoming.txt
+++ b/source/limitations-upcoming.txt
@@ -131,7 +131,6 @@ Querying Limitations
 
 {+django-odm+} does not support the following ``QuerySet`` API methods:
 
-- ``distinct()``
 - ``dates()``
 - ``datetimes()``
 - ``prefetch_related()``


### PR DESCRIPTION
Applies to 5.1.x and 5.0.x.